### PR TITLE
ci: using tokens for publishing

### DIFF
--- a/.github/workflows/create-releases.yml
+++ b/.github/workflows/create-releases.yml
@@ -95,6 +95,7 @@ jobs:
         uses: pypa/gh-action-pypi-publish@v1.8.8
         with:
           skip-existing: true
+          password: ${{ secrets.PYPI_API_TOKEN }}
   prepare-for-dev-cycle:
     needs:
       - release


### PR DESCRIPTION
Until I figure out a way to use ODCI, tokens it is

Signed-off-by: Aaron <29749331+aarnphm@users.noreply.github.com>
