### PR TITLE
fix(vllm): correctly read env for EnvVarMixin

### DIFF
--- a/changelog.d/181.fix.md
+++ b/changelog.d/181.fix.md
@@ -1,0 +1,6 @@
+Fixes a bug with `EnvVarMixin` where it didn't respect environment variable for specific fields
+
+This inherently provide a confusing behaviour with `--model-id`. This is now has been addressed with main
+
+The base docker will now also include a installation of xformers from source, locked at a given hash, since the latest release of xformers
+are too old and would fail with vLLM when running within the k8s

--- a/src/openllm/_configuration.py
+++ b/src/openllm/_configuration.py
@@ -622,7 +622,7 @@ def structure_settings(cl_: type[LLMConfig], cls: type[_ModelSettingsAttr]) -> _
   _final_value_dct["env"] = env
 
   # bettertransformer support
-  if _settings_attr["bettertransformer"] is None: _final_value_dct["bettertransformer"] = str(env.bettertransformer_value).upper() in ENV_VARS_TRUE_VALUES
+  if _settings_attr["bettertransformer"] is None: _final_value_dct["bettertransformer"] = str(env["bettertransformer_value"]).upper() in ENV_VARS_TRUE_VALUES
   # if requires_gpu is True, then disable BetterTransformer for quantization.
   if _settings_attr["requires_gpu"]: _final_value_dct["bettertransformer"] = False
   _final_value_dct["service_name"] = f"generated_{model_name}_service.py"
@@ -1485,4 +1485,6 @@ def structure_llm_config(data: DictStrAny, cls: type[LLMConfig]) -> LLMConfig:
 
 bentoml_cattr.register_structure_hook_func(lambda cls: lenient_issubclass(cls, LLMConfig), structure_llm_config)
 
-openllm_home = os.path.expanduser(os.getenv("OPENLLM_HOME", os.path.join(os.getenv("XDG_CACHE_HOME", os.path.join(os.path.expanduser("~"), ".cache")), "openllm")))
+openllm_home = os.path.expanduser(os.environ.get("OPENLLM_HOME", os.path.join(os.environ.get("XDG_CACHE_HOME", os.path.join(os.path.expanduser("~"), ".cache")), "openllm")))
+
+__all__ = ["LLMConfig", "field_env_key"]

--- a/src/openllm/_strategies.py
+++ b/src/openllm/_strategies.py
@@ -86,7 +86,7 @@ def _parse_visible_devices(default_var: str = ..., *, respect_env: t.Literal[Fal
 def _parse_visible_devices(default_var: str | None = None, respect_env: bool = True) -> list[str] | None:
   """CUDA_VISIBLE_DEVICES aware with default var for parsing spec."""
   if respect_env:
-    spec = os.getenv("CUDA_VISIBLE_DEVICES", default_var)
+    spec = os.environ.get("CUDA_VISIBLE_DEVICES", default_var)
     if not spec: return None
   else:
     if default_var is None: raise ValueError("spec is required to be not None when parsing spec.")
@@ -370,11 +370,11 @@ class CascadingResourceStrategy(bentoml.Strategy, ReprMixin):
       if runnable_class.SUPPORTS_CPU_MULTI_THREADING:
         thread_count = math.ceil(cpus)
         for thread_env in THREAD_ENVS:
-          environ[thread_env] = os.getenv(thread_env, str(thread_count))
+          environ[thread_env] = os.environ.get(thread_env, str(thread_count))
         logger.debug("Environ for worker %s: %s", worker_index, environ)
         return environ
       for thread_env in THREAD_ENVS:
-        environ[thread_env] = os.getenv(thread_env, "1")
+        environ[thread_env] = os.environ.get(thread_env, "1")
       return environ
     return environ
 

--- a/src/openllm/bundle/_package.py
+++ b/src/openllm/bundle/_package.py
@@ -135,17 +135,17 @@ def construct_docker_options(
   _bentoml_config_options += " " if _bentoml_config_options else "" + " ".join(_bentoml_config_options_opts)
   env: EnvVarMixin = llm.config["env"]
   env_dict = {
-      env.framework: env.framework_value, env.config: f"'{llm.config.model_dump_json().decode()}'", "OPENLLM_MODEL": llm.config["model_name"], "OPENLLM_SERIALIZATION": serialisation_format,
-      "OPENLLM_ADAPTER_MAP": f"'{orjson.dumps(adapter_map).decode()}'", "BENTOML_DEBUG": str(True), "BENTOML_QUIET": str(False), "BENTOML_CONFIG_OPTIONS": f"'{_bentoml_config_options}'",
-      env.model_id: f"/home/bentoml/bento/models/{llm.tag.path()}"}
+      env.framework: env["framework_value"], env.config: f"'{llm.config.model_dump_json().decode()}'", "OPENLLM_MODEL": llm.config["model_name"], "OPENLLM_SERIALIZATION": serialisation_format, "OPENLLM_ADAPTER_MAP": f"'{orjson.dumps(adapter_map).decode()}'", "BENTOML_DEBUG": str(True), "BENTOML_QUIET": str(False), "BENTOML_CONFIG_OPTIONS": f"'{_bentoml_config_options}'",
+      env.model_id: f"/home/bentoml/bento/models/{llm.tag.path()}"
+  }
   if adapter_map: env_dict["BITSANDBYTES_NOWELCOME"] = os.environ.get("BITSANDBYTES_NOWELCOME", "1")
 
   # We need to handle None separately here, as env from subprocess doesn't accept None value.
   _env = EnvVarMixin(llm.config["model_name"], bettertransformer=bettertransformer, quantize=quantize, runtime=runtime)
 
-  if _env.bettertransformer_value is not None: env_dict[_env.bettertransformer] = str(_env.bettertransformer_value)
-  if _env.quantize_value is not None: env_dict[_env.quantize] = _env.quantize_value
-  env_dict[_env.runtime] = _env.runtime_value
+  env_dict[_env.bettertransformer] = str(_env["bettertransformer_value"])
+  if _env["quantize_value"] is not None: env_dict[_env.quantize] = t.cast(str, _env["quantize_value"])
+  env_dict[_env.runtime] = _env["runtime_value"]
   return DockerOptions(base_image=f"{oci.CONTAINER_NAMES[container_registry]}:{oci.get_base_container_tag(container_version_strategy)}", env=env_dict, dockerfile_template=dockerfile_template)
 
 @inject

--- a/src/openllm/bundle/oci/Dockerfile
+++ b/src/openllm/bundle/oci/Dockerfile
@@ -118,6 +118,20 @@ git fetch && git checkout ${COMMIT_HASH}
 TORCH_CUDA_ARCH_LIST="7.5;8.0;8.6+PTX;8.9;9.0" python setup.py build
 EOT
 
+# NOTE: Build xformers from source since the latest xformers are too old
+FROM kernel-builder as xformers-builder
+
+ENV COMMIT_HASH 2d3a2217c263419243b70c53f725213d1c386b0f
+ARG COMMIT_HASH=${COMMIT_HASH}
+
+WORKDIR /usr/src
+
+RUN <<EOT
+git clone https://github.com/facebookresearch/xformers.git && cd xformers
+git fetch && git checkout ${COMMIT_HASH}
+TORCH_CUDA_ARCH_LIST="7.5;8.0;8.6+PTX;8.9;9.0" python setup.py build
+EOT
+
 # base image
 FROM nvidia/cuda:11.8.0-cudnn8-runtime-ubuntu22.04 as base-container
 
@@ -145,6 +159,9 @@ COPY --from=flash-attn-v2-builder /usr/src/flash-attention-v2/build/lib.linux-x8
 # Copy build artefacts for auto-gptq
 COPY --from=auto-gptq-builder /usr/src/AutoGPTQ/build/lib.linux-x86_64-cpython-39 /opt/conda/lib/python3.9/site-packages
 
+# Copy build artefacts for xformers
+COPY --from=auto-gptq-builder /usr/src/xformers/build/lib.linux-x86_64-cpython-39 /opt/conda/lib/python3.9/site-packages
+
 # Install required dependencies
 COPY src src
 COPY hatch.toml README.md CHANGELOG.md pyproject.toml ./
@@ -158,7 +175,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-ins
         rm -rf /var/lib/apt/lists/*
 
 # Install all required dependencies
-RUN pip install  "ray==2.6.0" "jax[cuda11_local]" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html ".[opt,mpt,fine-tune,llama,falcon,chatglm]" -v --no-cache-dir
+RUN pip install  "ray==2.6.0" "einops" "jax[cuda11_local]" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html ".[opt,mpt,fine-tune,llama,chatglm]" -v --no-cache-dir
 
 FROM base-container
 

--- a/src/openllm/cli/termui.py
+++ b/src/openllm/cli/termui.py
@@ -26,7 +26,7 @@ def echo(text: t.Any, fg: str = "green", _with_style: bool = True, **attrs: t.An
   attrs["fg"], call = fg if not get_debug_mode() else None, click.echo if not _with_style else click.secho
   if not get_quiet_mode(): call(text, **attrs)
 
-COLUMNS = int(os.getenv("COLUMNS", str(120)))
+COLUMNS: int = int(os.environ.get("COLUMNS", str(120)))
 
 CONTEXT_SETTINGS = {"help_option_names": ["-h", "--help"], "max_content_width": COLUMNS, "token_normalize_func": inflection.underscore}
 

--- a/src/openllm/models/auto/factory.py
+++ b/src/openllm/models/auto/factory.py
@@ -48,7 +48,7 @@ class BaseAutoLLMClass:
         >>> llm = openllm.AutoLLM.for_model("flan-t5")
         ```
         """
-    llm = cls.infer_class_from_name(model).from_pretrained(model_id, model_version=model_version, llm_config=llm_config, **attrs)
+    llm = cls.infer_class_from_name(model).from_pretrained(model_id=model_id, model_version=model_version, llm_config=llm_config, **attrs)
     if ensure_available: llm.ensure_model_id_exists()
     return llm
 

--- a/src/openllm/utils/__init__.py
+++ b/src/openllm/utils/__init__.py
@@ -124,7 +124,7 @@ def field_env_key(model_name: str, key: str, suffix: str | t.Literal[""] | None 
   return "_".join(filter(None, map(str.upper, ["OPENLLM", model_name, suffix.strip("_") if suffix else "", key])))
 
 # Special debug flag controled via OPENLLMDEVDEBUG
-DEBUG = sys.flags.dev_mode or (not sys.flags.ignore_environment and bool(os.getenv(DEV_DEBUG_VAR)))
+DEBUG: bool = sys.flags.dev_mode or (not sys.flags.ignore_environment and bool(os.environ.get(DEV_DEBUG_VAR)))
 # MYPY is like t.TYPE_CHECKING, but reserved for Mypy plugins
 MYPY = False
 SHOW_CODEGEN = DEBUG and int(os.environ.get("OPENLLMDEVDEBUG", str(0))) > 3


### PR DESCRIPTION
This inherently fix vLLM loading bug for incorrect model_id

We also include xformers from source since the latest stable xformers are too old, which will break vLLM workers.

Signed-off-by: aarnphm-ec2-dev <29749331+aarnphm@users.noreply.github.com>
