### PR TITLE
chore(build): use latest vllm pre-built kernel

### DIFF
--- a/openllm-python/pyproject.toml
+++ b/openllm-python/pyproject.toml
@@ -102,7 +102,7 @@ falcon = ["einops", "xformers"]
 fine-tune = ["peft>=0.4.0", "bitsandbytes", "datasets", "accelerate", "trl"]
 flan-t5 = ["flax>=0.7", "jax", "jaxlib", "tensorflow", "keras"]
 full = [
-    "openllm[agents,baichuan,chatglm,falcon,fine-tune,flan-t5,ggml,gptq,grpc,llama,mpt,openai,opt,playground,starcoder,vllm]",
+  "openllm[agents,baichuan,chatglm,falcon,fine-tune,flan-t5,ggml,gptq,grpc,llama,mpt,openai,opt,playground,starcoder,vllm]",
 ]
 ggml = ["ctransformers"]
 gptq = ["auto-gptq[triton]"]
@@ -113,7 +113,7 @@ openai = ["openai", "tiktoken"]
 opt = ["flax>=0.7", "jax", "jaxlib", "tensorflow", "keras"]
 playground = ["jupyter", "notebook", "ipython", "jupytext", "nbformat"]
 starcoder = ["bitsandbytes"]
-vllm = ["vllm", "ray"]
+vllm = ["vllm>=0.1.4", "ray"]
 
 [tool.hatch.version]
 fallback-version = "0.0.0"

--- a/openllm-python/src/openllm/bundle/oci/Dockerfile
+++ b/openllm-python/src/openllm/bundle/oci/Dockerfile
@@ -60,20 +60,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends ninja-build && 
 RUN /opt/conda/bin/conda install -c "nvidia/label/cuda-11.8.0"  cuda==11.8 && \
     /opt/conda/bin/conda clean -ya
 
-# NOTE: Build vllm CUDA kernels
-FROM kernel-builder as vllm-builder
-
-ENV COMMIT_HASH d1744376ae9fdbfa6a2dc763e1c67309e138fa3d
-ARG COMMIT_HASH=${COMMIT_HASH}
-
-WORKDIR /usr/src
-
-RUN <<EOT
-git clone https://github.com/vllm-project/vllm.git && cd vllm
-git fetch && git checkout ${COMMIT_HASH}
-python setup.py build
-EOT
-
 # NOTE: Build flash-attention-2 CUDA kernels
 FROM kernel-builder as flash-attn-v2-builder
 
@@ -122,9 +108,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # Copy conda with PyTorch installed
 COPY --from=pytorch-install /opt/conda /opt/conda
 
-# Copy build artefacts for vllm
-COPY --from=vllm-builder /usr/src/vllm/build/lib.linux-x86_64-cpython-39 /opt/conda/lib/python3.9/site-packages
-
 # Copy build artefacts for flash-attention-v2
 COPY --from=flash-attn-v2-builder /usr/src/flash-attention-v2/build/lib.linux-x86_64-cpython-39 /opt/conda/lib/python3.9/site-packages
 
@@ -146,7 +129,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-ins
 # Install all required dependencies
 RUN --mount=type=cache,target=/root/.cache/pip \
   pip install --extra-index-url "https://download.pytorch.org/whl/cu118" -v --no-cache-dir \
-    "ray==2.6.0" "einops" "torch>=2.0.1+cu118" xformers "jax[cuda11_local]" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html ".[opt,mpt,fine-tune,llama,chatglm]"
+    "ray==2.6.0" "einops" "vllm>=0.1.4" "torch>=2.0.1+cu118" xformers "jax[cuda11_local]" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html ".[opt,mpt,fine-tune,llama,chatglm]"
 
 FROM base-container
 

--- a/tools/dependencies.py
+++ b/tools/dependencies.py
@@ -125,7 +125,7 @@ AGENTS_DEPS = ['transformers[agents]>=4.30', 'diffusers', 'soundfile']
 PLAYGROUND_DEPS = ['jupyter', 'notebook', 'ipython', 'jupytext', 'nbformat']
 GGML_DEPS = ['ctransformers']
 GPTQ_DEPS = ['auto-gptq[triton]']
-VLLM_DEPS = ['vllm', 'ray']
+VLLM_DEPS = ['vllm>=0.1.4', 'ray']
 
 _base_requirements: dict[str, t.Any] = {
     inflection.dasherize(name): config_cls.__openllm_requirements__ for name, config_cls in openllm.CONFIG_MAPPING.items() if config_cls.__openllm_requirements__


### PR DESCRIPTION
vllm now include prebuilt kernel so that we don't have to build it ourself anymore

Signed-off-by: Aaron <29749331+aarnphm@users.noreply.github.com>
