### PR TITLE
fix(serving): vllm bad num_gpus

### DIFF
--- a/openllm-python/src/openllm/_assign.py
+++ b/openllm-python/src/openllm/_assign.py
@@ -52,7 +52,7 @@ def load_model(fn: load_model_protocol[M, T]) -> t.Callable[[LLM[M, T]], M | vll
   def inner(self: LLM[M, T], *decls: t.Any, **attrs: t.Any) -> M | vllm.LLMEngine:
     if self.__llm_backend__ == 'vllm':
       num_gpus, dev = 1, device_count()
-      if dev >= 2: num_gpus = dev if dev // 2 == 0 else math.ceil(dev / 2)
+      if dev >= 2: num_gpus = min(dev // 2 * 2, dev)
       # TODO: Do some more processing with token_id once we support token streaming
       try:
         return vllm.LLMEngine.from_engine_args(

--- a/openllm-python/src/openllm/_assign.py
+++ b/openllm-python/src/openllm/_assign.py
@@ -1,7 +1,6 @@
 '''LLM assignment magik.'''
 from __future__ import annotations
 import functools
-import math
 import traceback
 import typing as t
 


### PR DESCRIPTION
When using VLLM with a machine with 4 GPUs, `tensor_parallel_size` is set to 2 instead of 4.

It's because the line making sure `num_gpus` is divisible by 2 is not right.
If `dev` is 4, `dev // 2` is 2 and 2 is not equal to 0.
Using `ceil` is not right either, if `dev` is 5, `ceil(dev / 2)` is 3 whereas it should be 4.

This PR fixes both issues.
It makes sure `num_gpus` is always divisible by 2 while taking the maximum number of GPUs possible (if there are 7 GPUs, 6 GPUs are taken).

Related PR: https://github.com/bentoml/OpenLLM/pull/285