### PR TITLE
refactor(strategies): move logics into openllm-python

### DIFF
--- a/openllm-core/pyproject.toml
+++ b/openllm-core/pyproject.toml
@@ -62,6 +62,7 @@ dependencies = [
   "cattrs>=23.1.0",
   "orjson",
   "inflection",
+  "deepmerge",
   "typing_extensions",
   "mypy_extensions",
 ]

--- a/openllm-core/src/openllm_core/utils/peft.py
+++ b/openllm-core/src/openllm_core/utils/peft.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+import enum, typing as t, inflection, attr
+from deepmerge import Merger
+from . import dantic
+from ..exceptions import ForbiddenAttributeError
+
+config_merger = Merger([(dict, 'merge')], ['override'], ['override'])
+
+if t.TYPE_CHECKING:
+  from peft.config import PeftConfig
+  from .._typing_compat import AdapterType
+  from .._configuration import LLMConfig
+
+# case insensitive, but rename to conform with type
+class _PeftEnumMeta(enum.EnumMeta):
+  def __getitem__(self, __key: str | t.Any, /) -> t.Any:
+    if isinstance(__key, str): __key = inflection.underscore(__key).upper()
+    return self._member_map_[__key]
+
+# vendorred from peft.utils.config.PeftType since we don't have hard dependency on peft
+# see https://github.com/huggingface/peft/blob/main/src/peft/utils/config.py
+class PeftType(str, enum.Enum, metaclass=_PeftEnumMeta):
+  PROMPT_TUNING = 'PROMPT_TUNING'
+  MULTITASK_PROMPT_TUNING = 'MULTITASK_PROMPT_TUNING'
+  P_TUNING = 'P_TUNING'
+  PREFIX_TUNING = 'PREFIX_TUNING'
+  LORA = 'LORA'
+  ADALORA = 'ADALORA'
+  ADAPTION_PROMPT = 'ADAPTION_PROMPT'
+  IA3 = 'IA3'
+  LOHA = 'LOHA'
+  LOKR = 'LOKR'
+
+  @classmethod
+  def _missing_(cls, value: object) -> enum.Enum | None:
+    if isinstance(value, str):
+      normalized = inflection.underscore(value).upper()
+      if normalized in cls._member_map_: return cls._member_map_[normalized]
+    return None
+
+  @classmethod
+  def supported(cls) -> set[str]:
+    return {inflection.underscore(v.value) for v in cls}
+
+  @staticmethod
+  def get(__key: str | t.Any, /) -> PeftType:
+    return PeftType[__key]  # type-safe getitem.
+
+PEFT_TASK_TYPE_TARGET_MAPPING = {'causal_lm': 'CAUSAL_LM', 'seq2seq_lm': 'SEQ_2_SEQ_LM'}
+
+_object_setattr = object.__setattr__
+
+def _adapter_converter(value: AdapterType | str | PeftType | None) -> PeftType:
+  if value is None: raise ValueError("'AdapterType' cannot be None.")
+  if isinstance(value, PeftType): return value
+  if value not in PeftType.supported(): raise ValueError(f"Given '{value}' is not a supported adapter type.")
+  return PeftType.get(value)
+
+@attr.define(slots=True, init=True)
+class FineTuneConfig:
+  adapter_type: PeftType = dantic.Field('lora',
+                                        description=f"The type of adapter to use for fine-tuning. Available supported methods: {PeftType.supported()}, default to 'lora'",
+                                        use_default_converter=False,
+                                        converter=_adapter_converter)
+  adapter_config: t.Dict[str, t.Any] = dantic.Field(None,
+                                                    description='The configuration for the adapter. The content of the dict depends on the adapter type.',
+                                                    validator=attr.validators.optional(attr.validators.instance_of(dict)),
+                                                    converter=attr.converters.default_if_none(factory=dict),
+                                                    use_default_converter=False)
+  inference_mode: bool = dantic.Field(False, description='Whether to use this Adapter for inference', use_default_converter=False)
+  llm_config_class: type[LLMConfig] = dantic.Field(None, description='The reference class to openllm.LLMConfig', use_default_converter=False)
+
+  def build(self) -> PeftConfig:
+    try:
+      from peft import TaskType, PEFT_TYPE_TO_CONFIG_MAPPING, get_peft_config
+    except ImportError:
+      raise ImportError('PEFT is not installed. Please install it via `pip install "openllm[fine-tune]"`.')
+    adapter_config = self.adapter_config.copy()
+    # no need for peft_type
+    if 'peft_type' in adapter_config: adapter_config.pop('peft_type')
+    for k in {'enable_lora', 'merge_weights'}:  # these keys are from older PEFT and no longer valid.
+      if k in adapter_config: adapter_config.pop(k)
+    # respect user set task_type if it is passed, otherwise use one managed by OpenLLM
+    inference_mode = adapter_config.pop('inference_mode', self.inference_mode)
+    task_type = adapter_config.pop('task_type', TaskType[self.llm_config_class.peft_task_type()])
+    adapter_config = {'peft_type': self.adapter_type.value, "task_type": task_type, "inference_mode": inference_mode, **adapter_config}
+    return get_peft_config(adapter_config)
+
+  def train(self) -> FineTuneConfig:
+    _object_setattr(self, 'inference_mode', False)
+    return self
+
+  def eval(self) -> FineTuneConfig:
+    _object_setattr(self, 'inference_mode', True)
+    return self
+
+  def with_config(self, **attrs: t.Any) -> FineTuneConfig:
+    adapter_type, inference_mode = attrs.pop('adapter_type', self.adapter_type), attrs.get('inference_mode', self.inference_mode)
+    if 'llm_config_class' in attrs: raise ForbiddenAttributeError("'llm_config_class' should not be passed when using 'with_config'.")
+    return attr.evolve(self, adapter_type=adapter_type, inference_mode=inference_mode, adapter_config=config_merger.merge(self.adapter_config, attrs))

--- a/openllm-python/src/openllm/_llm.py
+++ b/openllm-python/src/openllm/_llm.py
@@ -19,7 +19,7 @@ from bentoml._internal.models.model import ModelSignature
 from bentoml._internal.runner.runner_handle import DummyRunnerHandle
 from openllm_core._schemas import CompletionChunk
 from openllm_core._schemas import GenerationOutput
-from openllm_core._strategies import CascadingResourceStrategy
+from ._strategies import CascadingResourceStrategy
 from openllm_core._typing_compat import AdapterMap
 from openllm_core._typing_compat import AdapterTuple
 from openllm_core._typing_compat import AdapterType

--- a/openllm-python/src/openllm/_strategies.py
+++ b/openllm-python/src/openllm/_strategies.py
@@ -1,4 +1,3 @@
-# NOTE: This module depends on BentoML, whereas openllm_core doesn't necessary depends on BentoML.
 # mypy: disable-error-code="no-redef"
 from __future__ import annotations
 import inspect
@@ -10,20 +9,15 @@ import types
 import typing as t
 import warnings
 
-import psutil
-
-try:
-  import bentoml
-except ImportError:
-  raise RuntimeError("Importing 'openllm_core._strategies' requires bentoml (not available locally). Make sure to do 'pip install -U bentoml'")
+import psutil, bentoml
 
 from bentoml._internal.resource import get_resource
 from bentoml._internal.resource import system_resources
 from bentoml._internal.runner.strategy import THREAD_ENVS
 
-from ._typing_compat import overload
-from .utils import DEBUG
-from .utils import ReprMixin
+from openllm_core._typing_compat import overload
+from openllm_core.utils import DEBUG
+from openllm_core.utils import ReprMixin
 
 class DynResource(t.Protocol):
   resource_id: t.ClassVar[str]
@@ -230,7 +224,7 @@ def _make_resource_class(name: str, resource_kind: str, docstring: str) -> type[
           '__module__': 'openllm._strategies'
       }))
 
-# NOTE: we need to hint these t.Literal since mypy is to dumb to infer this as literal :facepalm:
+# NOTE: we need to hint these t.Literal since mypy is to dumb to infer this as literal 🤦
 _TPU_RESOURCE: t.Literal['cloud-tpus.google.com/v2'] = 'cloud-tpus.google.com/v2'
 _AMD_GPU_RESOURCE: t.Literal['amd.com/gpu'] = 'amd.com/gpu'
 _NVIDIA_GPU_RESOURCE: t.Literal['nvidia.com/gpu'] = 'nvidia.com/gpu'

--- a/openllm-python/src/openllm/cli/entrypoint.py
+++ b/openllm-python/src/openllm/cli/entrypoint.py
@@ -369,25 +369,6 @@ def import_command(model_name: str, model_id: str | None, converter: str | None,
   > If ``quantize`` is passed, the model weights will be saved as quantized weights. You should
   > only use this option if you want the weight to be quantized by default. Note that OpenLLM also
   > support on-demand quantisation during initial startup.
-
-  \b
-  ## Conversion strategies [EXPERIMENTAL]
-
-  \b
-  Some models will include built-in conversion strategies for specific weights format.
-  It will be determined via the `CONVERTER` environment variable. Note that this envvar should only be use provisionally as it is not RECOMMENDED to export this
-  and save to a ``.env`` file.
-
-  The conversion strategies will have the following format and will be determined per architecture implementation:
-  <base_format>-<target_format>
-
-  \b
-  For example: the below convert LlaMA-2 model format to hf:
-
-  \b
-  ```bash
-  $ CONVERTER=llama2-hf openllm import llama /path/to/llama-2
-  ```
   """
   llm_config = openllm.AutoConfig.for_model(model_name)
   _serialisation = t.cast(LiteralSerialisation, first_not_none(serialisation, default=llm_config['serialisation']))

--- a/openllm-python/tests/strategies_test.py
+++ b/openllm-python/tests/strategies_test.py
@@ -6,10 +6,10 @@ import pytest
 
 import bentoml
 
-from openllm_core import _strategies as strategy
-from openllm_core._strategies import CascadingResourceStrategy
-from openllm_core._strategies import NvidiaGpuResource
-from openllm_core._strategies import get_resource
+from openllm import _strategies as strategy
+from openllm._strategies import CascadingResourceStrategy
+from openllm._strategies import NvidiaGpuResource
+from openllm._strategies import get_resource
 
 if t.TYPE_CHECKING:
   from _pytest.monkeypatch import MonkeyPatch


### PR DESCRIPTION
Strategies shouldn't be a part of openllm-core

Signed-off-by: Aaron <29749331+aarnphm@users.noreply.github.com>
