### PR TITLE
fix(runner): remove keyword args for attrs.get()

### DIFF
--- a/openllm-python/src/openllm/_deprecated.py
+++ b/openllm-python/src/openllm/_deprecated.py
@@ -55,7 +55,7 @@ def Runner(
     logger.warning(
       "'ensure_available=False' won't have any effect as LLM will always check to download the model on initialisation."
     )
-  model_id = attrs.get('model_id', default=os.getenv('OPENLLM_MODEL_ID', llm_config['default_id']))
+  model_id = attrs.get('model_id', os.getenv('OPENLLM_MODEL_ID', llm_config['default_id']))
   _RUNNER_MSG = f"""\
   Using 'openllm.Runner' is now deprecated. Make sure to switch to the following syntax:
 


### PR DESCRIPTION
Fix `TypeError` occured when using `openllm.Runner`

```
    lc_llm = OpenLLM(model_name=model_name, model_id=model_id, embedded=False, **attrs)
  File "/opt/conda/lib/python3.8/site-packages/langchain/llms/openllm.py", line 171, in __init__
    runner = openllm.Runner(
  File "/opt/conda/lib/python3.8/site-packages/openllm/_deprecated.py", line 58, in Runner
    model_id = attrs.get('model_id', default=os.getenv('OPENLLM_MODEL_ID', llm_config['default_id']))
TypeError: get() takes no keyword arguments
```