### PR TITLE
improv(package): use python slim base image and let pytorch install cuda

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile-upstream:master
 # Adapted from: https://github.com/pytorch/pytorch/blob/master/Dockerfile
-FROM nvidia/cuda:12.1.0-base-ubuntu22.04 as base-container
+FROM python:3.11-slim as base-container
 
 # Automatically set by buildx
 ARG TARGETPLATFORM

--- a/openllm-python/src/openllm/bundle/_package.py
+++ b/openllm-python/src/openllm/bundle/_package.py
@@ -61,7 +61,7 @@ def construct_docker_options(llm, _, quantize, adapter_map, dockerfile_template,
   environ['OPENLLM_CONFIG'] = f"'{environ['OPENLLM_CONFIG']}'"
   environ.pop('BENTOML_HOME', None)  # NOTE: irrelevant in container
   environ['NVIDIA_DRIVER_CAPABILITIES'] = 'compute,utility'
-  return DockerOptions(cuda_version='12.1', python_version='3.11', env=environ, dockerfile_template=dockerfile_template)
+  return DockerOptions(python_version='3.11', env=environ, dockerfile_template=dockerfile_template)
 
 
 @inject


### PR DESCRIPTION
We can let pytorch install it's own cuda runtime and save some duplicate spaces