### PR TITLE
chore: fix typo in list_models pydoc

### DIFF
--- a/openllm-python/src/openllm_cli/extension/list_models.py
+++ b/openllm-python/src/openllm_cli/extension/list_models.py
@@ -18,7 +18,7 @@ if t.TYPE_CHECKING:
 @click.command('list_models', context_settings=termui.CONTEXT_SETTINGS)
 @model_name_argument(required=False, shell_complete=model_complete_envvar)
 def cli(model_name: str | None) -> DictStrAny:
-  """List available models in lcoal store to be used wit OpenLLM."""
+  """List available models in local store to be used with OpenLLM."""
   models = tuple(inflection.dasherize(key) for key in openllm.CONFIG_MAPPING.keys())
   ids_in_local_store = {
     k: [


### PR DESCRIPTION
Fixes a typo in the pydoc / cli help output