### PR TITLE
fix: limit BentoML version range

### DIFF
--- a/openllm-client/pyproject.toml
+++ b/openllm-client/pyproject.toml
@@ -67,7 +67,7 @@ Tracker = "https://github.com/bentoml/OpenLLM/issues"
 Twitter = "https://twitter.com/bentomlai"
 [project.optional-dependencies]
 full = ["openllm-client[grpc,agents,auth]"]
-grpc = ["bentoml[grpc]>=1.1.9"]
+grpc = ["bentoml[grpc]>=1.1.10,<1.2"]
 auth = ['httpx_auth']
 agents = ["transformers[agents]>=4.30", "diffusers", "soundfile"]
 

--- a/openllm-core/pyproject.toml
+++ b/openllm-core/pyproject.toml
@@ -81,7 +81,7 @@ Twitter = "https://twitter.com/bentomlai"
 [project.optional-dependencies]
 full = ["openllm-core[vllm,fine-tune,bentoml]"]
 vllm = ["vllm"]
-bentoml = ["bentoml>=1.1.2"]
+bentoml = ["bentoml>=1.1.10,<1.2"]
 fine-tune = [
     "transformers[torch,tokenizers,accelerate]>=4.34.0",
     "peft>=0.4.0",

--- a/openllm-python/src/openllm/bundle/_package.py
+++ b/openllm-python/src/openllm/bundle/_package.py
@@ -38,7 +38,7 @@ def build_editable(path, package='openllm'):
 def construct_python_options(llm, llm_fs, extra_dependencies=None, adapter_map=None):
   from . import RefResolver
 
-  packages = ['scipy', 'bentoml[tracing]>=1.1.10', f'openllm[vllm]>={RefResolver.from_strategy("release").version}']  # apparently bnb misses this one
+  packages = ['scipy', 'bentoml[tracing]>=1.1.10,<1.2', f'openllm[vllm]>={RefResolver.from_strategy("release").version}']  # apparently bnb misses this one
   if adapter_map is not None:
     packages += ['openllm[fine-tune]']
   if extra_dependencies is not None:


### PR DESCRIPTION
For openllm 0.4 branch, we want to limit BentoML version to >=1.1.10,<1.2