### PR TITLE
security: validate alias paths in list_bento to prevent path traversal

### DIFF
--- a/src/openllm/model.py
+++ b/src/openllm/model.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import re, typing, json
+import pathlib, re, typing, json
 import tabulate, questionary, typer
 
 from openllm.accelerator_spec import can_run
@@ -160,6 +160,12 @@ def list_bento(
         with open(path) as f:
           origin_name = f.read().strip()
         origin_path = path.parent / origin_name
+        if '..' in pathlib.PurePosixPath(origin_name).parts:
+          continue
+        try:
+          origin_path.resolve().relative_to(repo.path.resolve())
+        except ValueError:
+          continue
         model = BentoInfo(alias=path.name, repo=repo, path=origin_path)
       else:
         model = None


### PR DESCRIPTION
*Vulnerability identified and fix provided by [Kolega.dev](https://kolega.dev/)*

## Path Traversal via Symlink Following in Alias Resolution

## Location
`src/openllm/model.py:159-163`

## Description
The `list_bento` function reads alias files without validating their contents. If an alias file contains a path like `../../../etc/passwd`, the resulting `origin_path` will resolve outside the intended repo directory. No validation ensures `origin_path` stays within `repo.path`.

## Analysis Notes
Confirmed path traversal vulnerability. The `list_bento` function reads alias files at lines 159-163 and uses the content directly in path construction via `origin_path = path.parent / origin_name`. Alias files are created by `_complete_alias()` in `repo.py` which writes `bento.version` from the repository's `bento.yaml`. A malicious repository can set `version: '../../../sensitive/path'` in `bento.yaml`, causing the alias file to contain path traversal sequences. When the alias is read, no validation ensures `origin_path` remains within `repo.path`. The resulting `BentoInfo` object with a traversed path could be used to access files outside the intended repository directory. Exploitation requires adding a malicious repository via `openllm repo add`, which is a supported user operation.

## Fix Applied
Added two validation checks before constructing a `BentoInfo` from alias file contents: (1) reject alias values containing `..` path components using `pathlib.PurePosixPath.parts`, and (2) verify the resolved `origin_path` falls within the repo directory using `resolve()` and `relative_to()`. Both checks silently skip invalid aliases via `continue`, matching the existing pattern of skipping entries that don't match expected structures.

## Tests/Linters Ran
- `ruff check src/openllm/model.py` — passed (0 errors)
- `ruff format --check src/openllm/model.py` — passed (already formatted)
- `mypy --strict --ignore-missing-imports src/openllm/model.py` — no new errors (pre-existing stub-only warnings in dependencies)
- `pytest --collect-only` — no tests exist in the repository to run

## Contribution Notes
- Followed the development workflow described in `DEVELOPMENT.md`
- Matched existing code style: 2-space indentation, single quotes, `pathlib` usage consistent with `repo.py` and `common.py`
- No PR template was found in the repository