### PR TITLE
security: use create_subprocess_exec instead of create_subprocess_shell

### DIFF
--- a/src/openllm/common.py
+++ b/src/openllm/common.py
@@ -422,12 +422,8 @@ async def async_run_command(
 
   proc = None
   try:
-    proc = await asyncio.create_subprocess_shell(
-      ' '.join(map(str, cmd)),
-      stdout=asyncio.subprocess.PIPE,
-      stderr=asyncio.subprocess.PIPE,
-      cwd=cwd,
-      env=env,
+    proc = await asyncio.create_subprocess_exec(
+      *cmd, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE, cwd=cwd, env=env
     )
     yield proc
   except subprocess.CalledProcessError:


### PR DESCRIPTION
*Vulnerability identified and fix provided by [Kolega.dev](https://kolega.dev/)*

## Command Injection via Shell String Concatenation in async_run_command

## Location
`src/openllm/common.py:425-426`

## Description
The `async_run_command` function uses `asyncio.create_subprocess_shell` with `' '.join(map(str, cmd))` at line 426, which is a dangerous pattern. While `shlex` is imported, `shlex.quote()` is not applied to the joined command. The `cmd` list is constructed from: (1) `bentoml_tag` derived from filesystem paths, (2) `port` as an integer, and (3) `cli_args` from user CLI input. Using `create_subprocess_shell` with string concatenation bypasses the safety of list-based argument passing and can allow shell metacharacter injection.

## Analysis Notes
The synchronous `run_command` function correctly uses `subprocess.run` with a list of arguments. However, the async counterpart `async_run_command` concatenates arguments into a single shell string, which is an inconsistent and insecure pattern. While this is a local CLI tool with a limited practical attack surface, the pattern is objectively wrong and should be corrected.

## Fix Applied
Replaced `asyncio.create_subprocess_shell` with `asyncio.create_subprocess_exec`, passing `*cmd` as positional arguments instead of joining them into a shell string. This matches the secure pattern already used by the synchronous `run_command` function and eliminates any possibility of shell metacharacter injection.

## Tests/Linters Ran
- **ruff format**: Passed (`1 file already formatted` after auto-format)
- **ruff check**: Only pre-existing `F401` warning for unused `typer.core` import (not introduced by this change, verified against main branch)
- **Tests**: No test suite exists in the repository (`dependency-groups.tests` is defined in `pyproject.toml` but no test files exist)

## Contribution Notes
- Followed the project's development workflow as described in `DEVELOPMENT.md`
- Code style matches the project's conventions (2-space indentation, single quotes, ruff formatting)
- Change is minimal and focused solely on the security fix