### PR TITLE
Avoid shell in async command runner

### DIFF
--- a/src/openllm/common.py
+++ b/src/openllm/common.py
@@ -422,8 +422,8 @@ async def async_run_command(
 
   proc = None
   try:
-    proc = await asyncio.create_subprocess_shell(
-      ' '.join(map(str, cmd)),
+    proc = await asyncio.create_subprocess_exec(
+      *cmd,
       stdout=asyncio.subprocess.PIPE,
       stderr=asyncio.subprocess.PIPE,
       cwd=cwd,
@@ -435,7 +435,8 @@ async def async_run_command(
     raise typer.Exit(1)
   finally:
     if proc:
-      proc.send_signal(signal.SIGINT)
+      if proc.returncode is None:
+        proc.send_signal(signal.SIGINT)
       await proc.wait()
 
 

--- a/src/openllm/common.py
+++ b/src/openllm/common.py
@@ -423,11 +423,7 @@ async def async_run_command(
   proc = None
   try:
     proc = await asyncio.create_subprocess_exec(
-      *cmd,
-      stdout=asyncio.subprocess.PIPE,
-      stderr=asyncio.subprocess.PIPE,
-      cwd=cwd,
-      env=env,
+      *cmd, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE, cwd=cwd, env=env
     )
     yield proc
   except subprocess.CalledProcessError:

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1,0 +1,23 @@
+import asyncio
+import os
+
+from openllm.common import async_run_command
+
+
+def test_async_run_command_does_not_invoke_shell(tmp_path):
+  marker = tmp_path / 'shell_injection_marker.txt'
+  if os.name == 'nt':
+    separator = '&'
+    payload = ['cmd', '/c', f'echo PWNED>{marker}']
+  else:
+    separator = ';'
+    payload = ['sh', '-c', f'echo PWNED > {marker}']
+
+  async def run() -> None:
+    cmd = ['python', '-c', 'pass', separator, *payload]
+    async with async_run_command(cmd, cwd=str(tmp_path), silent=True) as proc:
+      await proc.wait()
+
+  asyncio.run(run())
+
+  assert not marker.exists()


### PR DESCRIPTION
## Summary

- replace `asyncio.create_subprocess_shell()` with `asyncio.create_subprocess_exec()` in `async_run_command()`
- keep command arguments as separate argv entries instead of joining them into a shell string
- avoid sending `SIGINT` after the subprocess has already exited
- add regression coverage for shell metacharacters in command arguments

## Test

```powershell
$env:PYTHONPATH='src'
python -m pytest tests\test_common.py -q
