### PR TITLE
Use exec for async command invocation

### DIFF
--- a/src/openllm/common.py
+++ b/src/openllm/common.py
@@ -422,8 +422,8 @@ async def async_run_command(
 
   proc = None
   try:
-    proc = await asyncio.create_subprocess_shell(
-      ' '.join(map(str, cmd)),
+    proc = await asyncio.create_subprocess_exec(
+      *cmd,
       stdout=asyncio.subprocess.PIPE,
       stderr=asyncio.subprocess.PIPE,
       cwd=cwd,
@@ -434,8 +434,11 @@ async def async_run_command(
     output('Command failed', style='red')
     raise typer.Exit(1)
   finally:
-    if proc:
-      proc.send_signal(signal.SIGINT)
+    if proc and proc.returncode is None:
+      try:
+        proc.send_signal(signal.SIGINT)
+      except ProcessLookupError:
+        pass
       await proc.wait()
 
 

--- a/src/openllm/common.py
+++ b/src/openllm/common.py
@@ -423,11 +423,7 @@ async def async_run_command(
   proc = None
   try:
     proc = await asyncio.create_subprocess_exec(
-      *cmd,
-      stdout=asyncio.subprocess.PIPE,
-      stderr=asyncio.subprocess.PIPE,
-      cwd=cwd,
-      env=env,
+      *cmd, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE, cwd=cwd, env=env
     )
     yield proc
   except subprocess.CalledProcessError:

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -13,12 +13,7 @@ async def _communicate(cmd: list[str]) -> tuple[int | None, str, str]:
 
 def test_async_run_command_preserves_shell_metacharacters() -> None:
   returncode, stdout, stderr = asyncio.run(
-    _communicate([
-      'python',
-      '-c',
-      'import sys; print(sys.argv[1])',
-      'literal-$(printf injected)',
-    ])
+    _communicate(['python', '-c', 'import sys; print(sys.argv[1])', 'literal-$(printf injected)'])
   )
 
   assert returncode == 0

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import asyncio
+
+from openllm.common import async_run_command
+
+
+async def _communicate(cmd: list[str]) -> tuple[int | None, str, str]:
+  async with async_run_command(cmd, silent=True) as proc:
+    stdout, stderr = await proc.communicate()
+  return proc.returncode, stdout.decode().strip(), stderr.decode().strip()
+
+
+def test_async_run_command_preserves_shell_metacharacters() -> None:
+  returncode, stdout, stderr = asyncio.run(
+    _communicate([
+      'python',
+      '-c',
+      'import sys; print(sys.argv[1])',
+      'literal-$(printf injected)',
+    ])
+  )
+
+  assert returncode == 0
+  assert stdout == 'literal-$(printf injected)'
+  assert stderr == ''


### PR DESCRIPTION
## Summary
- run async subprocesses with `create_subprocess_exec` instead of going through a shell
- preserve shell metacharacters as literal argv values
- avoid raising `ProcessLookupError` when the async process has already exited before cleanup

## Verification
- `.venv/bin/python -m pytest -q`
- `.venv/bin/python -m py_compile src/openllm/common.py tests/test_common.py`
- `git diff --check`

Note: `uv run --locked` currently asks to update the upstream `uv.lock` format with this local uv version, so I used the already-created project venv for verification without changing the lockfile.