### PR TITLE
feat: add Astraflow provider env vars to envrc template

### DIFF
--- a/.envrc.template
+++ b/.envrc.template
@@ -1,1 +1,8 @@
 export PAPERSPACE_API_KEY=
+
+# Astraflow (by UCloud) — OpenAI-compatible platform supporting 200+ models
+# Sign up: https://astraflow.ucloud-global.com (global) / https://astraflow.ucloud.cn (China)
+# Use ASTRAFLOW_API_KEY with base_url=https://api-us-ca.umodelverse.ai/v1
+# Use ASTRAFLOW_CN_API_KEY with base_url=https://api.modelverse.cn/v1
+export ASTRAFLOW_API_KEY=
+export ASTRAFLOW_CN_API_KEY=


### PR DESCRIPTION
## Summary

Adds [Astraflow](https://astraflow.ucloud-global.com) (by UCloud / 优刻得) environment variable entries to `.envrc.template`.

Astraflow is an OpenAI-compatible AI model aggregation platform supporting 200+ models. Because OpenLLM's interactive chat client (`openllm run`) uses the `openai` Python SDK internally (`openai.AsyncOpenAI(base_url=..., api_key=...)`), users can point it at any OpenAI-compatible endpoint — including Astraflow — by exporting these env vars and passing the appropriate `base_url`.

## New env vars

| Variable | Endpoint | Region |
|---|---|---|
| `ASTRAFLOW_API_KEY` | `https://api-us-ca.umodelverse.ai/v1` | Global |
| `ASTRAFLOW_CN_API_KEY` | `https://api.modelverse.cn/v1` | China |

## Sign up

- Global: https://astraflow.ucloud-global.com
- China: https://astraflow.ucloud.cn

## Changes

- `.envrc.template`: added `ASTRAFLOW_API_KEY` and `ASTRAFLOW_CN_API_KEY` with comments explaining their purpose and endpoints.