### PR TITLE
docs: fix typo in README.md (enviroment → environment)

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ openllm deploy llama3.2:1b --env HF_TOKEN
 ```
 
 > [!NOTE]
-> If you are deploying a gated model, make sure to set HF_TOKEN in enviroment variables.
+> If you are deploying a gated model, make sure to set HF_TOKEN in environment variables.
 
 Once the deployment is complete, you can run model inference on the BentoCloud console:
 


### PR DESCRIPTION
## Summary

Fixed a typo in `README.md` to improve documentation quality.

### Changes

| Typo | Correction | Location |
|------|-----------|----------|
| `enviroment` | `environment` | Deployment section (BentoCloud) |

### Details

- **Line 264**: Changed `HF_TOKEN in enviroment variables` → `HF_TOKEN in environment variables`

This is a straightforward spelling correction in the BentoCloud deployment instructions. The word "environment" was misspelled as "enviroment".