### PR TITLE
test: verify Veracode workspace routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,3 +290,5 @@ This project uses the following open-source projects:
 - [astral-sh/uv](https://github.com/astral-sh/uv) for blazing fast model requirements installing
 
 We are grateful to the developers and contributors of these projects for their hard work and dedication.
+
+<!-- Veracode workspace verification test, 2026-07-13, will be reverted immediately -->


### PR DESCRIPTION
Trivial change to trigger a fresh Veracode scan and confirm it routes to the bentoml/bentocollab SCA workspace. Will close/clean up immediately.