### PR TITLE
docs: add DaoXE OpenAI-compatible base_url client example

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,43 @@ llm = OpenAI(api_bese="http://localhost:3000/v1", model="meta-llama/Llama-3.2-1B
 
 </details>
 
+<details>
+
+<summary>Remote OpenAI-compatible gateway (DaoXE)</summary>
+
+The same OpenAI client works against any OpenAI-compatible base URL. For a multi-model multi-protocol cloud gateway (instead of a local OpenLLM server), point `base_url` at DaoXE:
+
+```python
+import os
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="https://daoxe.com/v1",
+    api_key=os.environ["DAOXE_API_KEY"],
+)
+
+# Model IDs are account-scoped — list what your key can access:
+# for m in client.models.list().data:
+#     print(m.id)
+
+chat_completion = client.chat.completions.create(
+    model=os.environ["DAOXE_MODEL"],  # e.g. an ID from GET /v1/models
+    messages=[
+        {
+            "role": "user",
+            "content": "Explain superconductors like I'm five years old",
+        }
+    ],
+    stream=True,
+)
+for chunk in chat_completion:
+    print(chunk.choices[0].delta.content or "", end="")
+```
+
+DaoXE exposes OpenAI Chat Completions / Responses and Anthropic Messages among other protocols; this example uses the OpenAI Chat Completions path only. Replace the model ID with one available to your key ([catalog](https://daoxe.com/pricing)). Not available in mainland China. Site: [daoxe.com](https://daoxe.com).
+
+</details>
+
 ## Chat UI
 
 OpenLLM provides a chat UI at the `/chat` endpoint for the launched LLM server at http://localhost:3000/chat.

--- a/README.md.tpl
+++ b/README.md.tpl
@@ -117,6 +117,43 @@ llm = OpenAI(api_bese="http://localhost:3000/v1", model="meta-llama/Llama-3.2-1B
 
 </details>
 
+<details>
+
+<summary>Remote OpenAI-compatible gateway (DaoXE)</summary>
+
+The same OpenAI client works against any OpenAI-compatible base URL. For a multi-model multi-protocol cloud gateway (instead of a local OpenLLM server), point `base_url` at DaoXE:
+
+```python
+import os
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="https://daoxe.com/v1",
+    api_key=os.environ["DAOXE_API_KEY"],
+)
+
+# Model IDs are account-scoped — list what your key can access:
+# for m in client.models.list().data:
+#     print(m.id)
+
+chat_completion = client.chat.completions.create(
+    model=os.environ["DAOXE_MODEL"],  # e.g. an ID from GET /v1/models
+    messages=[
+        {
+            "role": "user",
+            "content": "Explain superconductors like I'm five years old",
+        }
+    ],
+    stream=True,
+)
+for chunk in chat_completion:
+    print(chunk.choices[0].delta.content or "", end="")
+```
+
+DaoXE exposes OpenAI Chat Completions / Responses and Anthropic Messages among other protocols; this example uses the OpenAI Chat Completions path only. Replace the model ID with one available to your key ([catalog](https://daoxe.com/pricing)). Not available in mainland China. Site: [daoxe.com](https://daoxe.com).
+
+</details>
+
 ## Chat UI
 
 OpenLLM provides a chat UI at the `/chat` endpoint for the launched LLM server at http://localhost:3000/chat.


### PR DESCRIPTION
## Summary

Adds a third client example under **Start an LLM server** showing that the same OpenAI Python SDK pattern used with a local OpenLLM server also works against a remote OpenAI-compatible gateway.

- New `<details>` block: **Remote OpenAI-compatible gateway (DaoXE)**
- `base_url=https://daoxe.com/v1`, key via `DAOXE_API_KEY`, model via env / `GET /v1/models`
- Applied to both `README.md` and `README.md.tpl` so regenerated docs keep the example

### DaoXE notes

- Multi-model, multi-protocol AI API gateway (OpenAI Chat Completions / Responses, Anthropic Messages, and more). This example uses **OpenAI Chat Completions** only.
- Model IDs are **account-scoped** — list with `client.models.list()` or see [catalog](https://daoxe.com/pricing); no hard-coded public model IDs.
- Not available in mainland China.
- Site: https://daoxe.com · examples: https://github.com/seven7763/DaoXE-AI

I maintain DaoXE.

## Test plan

- [ ] README renders the new details section after the LlamaIndex example
- [ ] With a DaoXE key: `OpenAI(base_url="https://daoxe.com/v1", api_key=...)` chat completion works for an account-visible model ID
- [ ] Local OpenLLM `localhost:3000` examples remain unchanged