### PR TITLE
fix(clean): remove config file when resetting

### DIFF
--- a/src/openllm/clean.py
+++ b/src/openllm/clean.py
@@ -69,7 +69,7 @@ def repos(verbose: bool = False) -> None:
 def configs(verbose: bool = False) -> None:
   if verbose:
     VERBOSE_LEVEL.set(20)
-  shutil.rmtree(CONFIG_FILE, ignore_errors=True)
+  CONFIG_FILE.unlink(missing_ok=True)
   output('All configurations have been reset', style='green')
 
 

--- a/tests/test_clean.py
+++ b/tests/test_clean.py
@@ -1,0 +1,20 @@
+import pathlib
+
+import pytest
+from typer.testing import CliRunner
+
+from openllm import clean
+
+
+def test_clean_configs_removes_config_file(
+  tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+  config_file = tmp_path / 'config.json'
+  config_file.write_text('{"default_repo": "custom"}')
+  monkeypatch.setattr(clean, 'CONFIG_FILE', config_file)
+  monkeypatch.setenv('BENTOML_DO_NOT_TRACK', 'true')
+
+  result = CliRunner().invoke(clean.app, ['configs'])
+
+  assert result.exit_code == 0
+  assert not config_file.exists()


### PR DESCRIPTION
## Summary

- Fixes: Running `openllm clean configs` prints a successful reset message, but the existing config.json file and its custom repository settings remain in place.
- Root cause: The command passes CONFIG_FILE, which is a regular file, to shutil.rmtree with ignore_errors enabled; rmtree cannot remove files and the resulting error is silently discarded.

## Regression evidence

- Before: `PYTHONDONTWRITEBYTECODE=1 uv run --frozen --python 3.11 --group tests pytest tests/test_clean.py::test_clean_configs_removes_config_file -q` exited `1`

- After: `PYTHONDONTWRITEBYTECODE=1 uv run --frozen --python 3.11 --group tests pytest tests/test_clean.py::test_clean_configs_removes_config_file -q` exited `0`

## Verification

- `PYTHONDONTWRITEBYTECODE=1 uv run --frozen --python 3.11 --group tests pytest -q`
- `PYTHONDONTWRITEBYTECODE=1 uv run --isolated --frozen --python /usr/bin/python3 --group tests pytest tests/test_clean.py::test_clean_configs_removes_config_file -q`
- `PYTHONDONTWRITEBYTECODE=1 uv run --isolated --frozen --python 3.12 --group tests pytest tests/test_clean.py::test_clean_configs_removes_config_file -q`
- `PYTHONDONTWRITEBYTECODE=1 BENTOML_DO_NOT_TRACK=true uvx --python 3.11 pre-commit run --all-files`
- `uv build`
- `uvx --python 3.11 twine check dist/*.whl dist/*.tar.gz`
- `git diff --cached --check && git status --short && git diff --cached --stat`

## Scope

- 2 files changed, +21 / -1 lines
